### PR TITLE
添加OperatorVoiceItem结构及一些杂项更改

### DIFF
--- a/src/ArknightsResources.Operators.Models.csproj
+++ b/src/ArknightsResources.Operators.Models.csproj
@@ -17,9 +17,9 @@
     <Description>Provides models about Arknights Operators</Description>
     <IsTrimmable>true</IsTrimmable>
     <AnalysisLevel>latest</AnalysisLevel>
-    <Version>0.1.5.0-alpha</Version>
-    <AssemblyVersion>0.1.5.0</AssemblyVersion>
-    <FileVersion>0.1.5.0</FileVersion>
+    <Version>0.1.6.0-alpha</Version>
+    <AssemblyVersion>0.1.6.0</AssemblyVersion>
+    <FileVersion>0.1.6.0</FileVersion>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <DebugType>portable</DebugType>

--- a/src/OpVocal/OperatorVoiceInfo.cs
+++ b/src/OpVocal/OperatorVoiceInfo.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 namespace ArknightsResources.Operators.Models
 {
     /// <summary>
-    /// 表示干员配音信息的结构
+    /// 表示干员语音信息的结构
     /// </summary>
     public readonly struct OperatorVoiceInfo : IEquatable<OperatorVoiceInfo>
     {

--- a/src/OpVocal/OperatorVoiceInfo.cs
+++ b/src/OpVocal/OperatorVoiceInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace ArknightsResources.Operators.Models
@@ -12,24 +13,31 @@ namespace ArknightsResources.Operators.Models
         /// <summary>
         /// 初始化<see cref="OperatorVoiceInfo"/>结构的新实例
         /// </summary>
-        /// <param name="voice">配音人员</param>
+        /// <param name="cv">配音人员</param>
         /// <param name="type">配音的语言种类</param>
+        /// <param name="voices">语音条目</param>
         [JsonConstructor]
-        public OperatorVoiceInfo(string voice, OperatorVocalType type)
+        public OperatorVoiceInfo(string cv, OperatorVoiceType type, OperatorVoiceItem[] voices)
         {
-            Voice = voice;
+            CV = cv;
             Type = type;
+            Voices = voices;
         }
 
         /// <summary>
         /// 干员配音人员
         /// </summary>
-        public string Voice { get; }
+        public string CV { get; }
 
         /// <summary>
         /// 干员配音的语言种类
         /// </summary>
-        public OperatorVocalType Type { get; }
+        public OperatorVoiceType Type { get; }
+
+        /// <summary>
+        /// 干员的语音条目
+        /// </summary>
+        public OperatorVoiceItem[] Voices { get; }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
@@ -40,16 +48,18 @@ namespace ArknightsResources.Operators.Models
         /// <inheritdoc/>
         public bool Equals(OperatorVoiceInfo other)
         {
-            return Voice == other.Voice &&
-                   Type == other.Type;
+            return CV == other.CV &&
+                   Type == other.Type &&
+                   Voices.SequenceEqual(other.Voices);
         }
 
         /// <inheritdoc/>
         public override int GetHashCode()
         {
             int hashCode = 291305966;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Voice);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CV);
             hashCode = hashCode * -1521134295 + Type.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<OperatorVoiceItem[]>.Default.GetHashCode(Voices);
             return hashCode;
         }
 

--- a/src/OpVocal/OperatorVoiceItem.cs
+++ b/src/OpVocal/OperatorVoiceItem.cs
@@ -16,13 +16,15 @@ namespace ArknightsResources.Operators.Models
         /// <param name="voiceId">该条语音的包内ID(如"CN_007")</param>
         /// <param name="voiceTitle">该条语音的标题(如"信赖提升后交谈1")</param>
         /// <param name="voiceText">该条语音的文本</param>
+        /// <param name="voiceType">该条语音的语言种类</param>
         [JsonConstructor]
-        public OperatorVoiceItem(string charactorCodename, string voiceId, string voiceTitle, string voiceText)
+        public OperatorVoiceItem(string charactorCodename, string voiceId, string voiceTitle, string voiceText, OperatorVoiceType voiceType)
         {
             CharactorCodename = charactorCodename;
             VoiceId = voiceId;
             VoiceTitle = voiceTitle;
             VoiceText = voiceText;
+            VoiceType = voiceType;
         }
 
         /// <summary>
@@ -45,6 +47,11 @@ namespace ArknightsResources.Operators.Models
         /// </summary>
         public string VoiceText { get; }
 
+        /// <summary>
+        /// 该条语音的语言
+        /// </summary>
+        public OperatorVoiceType VoiceType { get; }
+
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
@@ -57,7 +64,8 @@ namespace ArknightsResources.Operators.Models
             return CharactorCodename == other.CharactorCodename &&
                    VoiceId == other.VoiceId &&
                    VoiceTitle == other.VoiceTitle &&
-                   VoiceText == other.VoiceText;
+                   VoiceText == other.VoiceText &&
+                   VoiceType == other.VoiceType;
         }
 
         /// <inheritdoc/>
@@ -68,6 +76,7 @@ namespace ArknightsResources.Operators.Models
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(VoiceId);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(VoiceTitle);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(VoiceText);
+            hashCode = hashCode * -1521134295 + EqualityComparer<OperatorVoiceType>.Default.GetHashCode(VoiceType);
             return hashCode;
         }
 

--- a/src/OpVocal/OperatorVoiceItem.cs
+++ b/src/OpVocal/OperatorVoiceItem.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ArknightsResources.Operators.Models
+{
+    /// <summary>
+    /// 表示一条干员语音的结构
+    /// </summary>
+    public readonly struct OperatorVoiceItem : IEquatable<OperatorVoiceItem>
+    {
+        /// <summary>
+        /// 初始化<see cref="OperatorVoiceItem"/>结构的新实例
+        /// </summary>
+        /// <param name="charactorCodename">该条语音所属干员的内部代号</param>
+        /// <param name="voiceId">该条语音的包内ID(如"CN_007")</param>
+        /// <param name="voiceTitle">该条语音的标题(如"信赖提升后交谈1")</param>
+        /// <param name="voiceText">该条语音的文本</param>
+        [JsonConstructor]
+        public OperatorVoiceItem(string charactorCodename, string voiceId, string voiceTitle, string voiceText)
+        {
+            CharactorCodename = charactorCodename;
+            VoiceId = voiceId;
+            VoiceTitle = voiceTitle;
+            VoiceText = voiceText;
+        }
+
+        /// <summary>
+        /// 该条语音所属干员的内部代号
+        /// </summary>
+        public string CharactorCodename { get; }
+
+        /// <summary>
+        /// 该条语音的ID
+        /// </summary>
+        public string VoiceId { get; }
+
+        /// <summary>
+        /// 该条语音的标题
+        /// </summary>
+        public string VoiceTitle { get; }
+
+        /// <summary>
+        /// 该条语音的文本
+        /// </summary>
+        public string VoiceText { get; }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return obj is OperatorVoiceItem item && Equals(item);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(OperatorVoiceItem other)
+        {
+            return CharactorCodename == other.CharactorCodename &&
+                   VoiceId == other.VoiceId &&
+                   VoiceTitle == other.VoiceTitle &&
+                   VoiceText == other.VoiceText;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            int hashCode = -1345095473;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CharactorCodename);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(VoiceId);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(VoiceTitle);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(VoiceText);
+            return hashCode;
+        }
+
+        /// <inheritdoc/>
+        public static bool operator ==(OperatorVoiceItem left, OperatorVoiceItem right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <inheritdoc/>
+        public static bool operator !=(OperatorVoiceItem left, OperatorVoiceItem right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/src/OpVocal/OperatorVoiceType.cs
+++ b/src/OpVocal/OperatorVoiceType.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// 干员配音的语言种类
     /// </summary>
-    public enum OperatorVocalType
+    public enum OperatorVoiceType
     {
         /// <summary>
         /// 中文普通话

--- a/src/Operator.cs
+++ b/src/Operator.cs
@@ -39,47 +39,47 @@ namespace ArknightsResources.Operators.Models
         /// <summary>
         /// 干员名称
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; }
 
         /// <summary>
         /// 干员星级
         /// </summary>
-        public int Star { get; set; }
+        public int Star { get; }
 
         /// <summary>
         /// 干员内部代号
         /// </summary>
-        public string Codename { get; set; }
+        public string Codename { get; }
 
         /// <summary>
         /// 干员性别
         /// </summary>
-        public OperatorGender Gender { get; set; }
+        public OperatorGender Gender { get; }
 
         /// <summary>
         /// 干员生日
         /// </summary>
-        public OperatorBirthday? Birthday { get; set; }
+        public OperatorBirthday? Birthday { get; }
 
         /// <summary>
         /// 干员职业
         /// </summary>
-        public OperatorClass Class { get; set; }
+        public OperatorClass Class { get; }
 
         /// <summary>
         /// 干员的立绘信息
         /// </summary>
-        public OperatorIllustrationInfo[] Illustrations { get; set; }
+        public OperatorIllustrationInfo[] Illustrations { get; }
 
         /// <summary>
         /// 干员的配音信息
         /// </summary>
-        public OperatorVoiceInfo[] Voices { get; set; }
+        public OperatorVoiceInfo[] Voices { get; }
 
         /// <summary>
         /// 干员档案
         /// </summary>
-        public OperatorProfile[] Profiles { get; set; }
+        public OperatorProfile[] Profiles { get; }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)

--- a/test/OperatorModelsTest.cs
+++ b/test/OperatorModelsTest.cs
@@ -11,7 +11,7 @@ namespace ArknightsResources.Operators.Models.Test
         [Fact]
         public void OperatorSerializeAndDeserializeTest()
         {
-            OperatorVoiceItem[] voices = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！") };
+            OperatorVoiceItem[] voices = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！", OperatorVoiceType.ChineseMandarin) };
 
             Operator testOperator = new("Baka632",
                                         6,
@@ -42,7 +42,7 @@ namespace ArknightsResources.Operators.Models.Test
         [Fact]
         public void OperatorsListSerializeAndDeserializeTest()
         {
-            OperatorVoiceItem[] voices = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！") };
+            OperatorVoiceItem[] voices = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！", OperatorVoiceType.ChineseMandarin) };
 
             Operator testOperator1 = new(
                     "Baka632",
@@ -98,7 +98,7 @@ namespace ArknightsResources.Operators.Models.Test
         [Fact]
         public void OperatorEqualityTest()
         {
-            OperatorVoiceItem[] voicesA = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！") };
+            OperatorVoiceItem[] voicesA = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！", OperatorVoiceType.ChineseMandarin) };
 
             Operator opA = new("Baka632",
                                         6,
@@ -110,7 +110,7 @@ namespace ArknightsResources.Operators.Models.Test
                                         new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVoiceType.ChineseMandarin, voicesA) },
                                         new OperatorProfile[] { new OperatorProfile("???", OperatorProfileType.Unknown) });
 
-            OperatorVoiceItem[] voicesB = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！") };
+            OperatorVoiceItem[] voicesB = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！",OperatorVoiceType.ChineseMandarin) };
 
             Operator opB = new("Baka632",
                                         6,

--- a/test/OperatorModelsTest.cs
+++ b/test/OperatorModelsTest.cs
@@ -1,4 +1,4 @@
-using System.Text.Encodings.Web;
+ï»¿using System.Text.Encodings.Web;
 using System.Text.Json.Serialization;
 using System.Text.Json;
 using System.Text.Unicode;
@@ -11,7 +11,7 @@ namespace ArknightsResources.Operators.Models.Test
         [Fact]
         public void OperatorSerializeAndDeserializeTest()
         {
-            OperatorVoiceItem[] voices = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "ÈÎÃüÖúÀí", "ÄãºÃÑ½²©Ê¿£¡", OperatorVoiceType.ChineseMandarin) };
+            OperatorVoiceItem[] voices = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "ä»»å‘½åŠ©ç†", "ä½ å¥½å‘€åšå£«ï¼", OperatorVoiceType.ChineseMandarin) };
 
             Operator testOperator = new("Baka632",
                                         6,
@@ -42,7 +42,7 @@ namespace ArknightsResources.Operators.Models.Test
         [Fact]
         public void OperatorsListSerializeAndDeserializeTest()
         {
-            OperatorVoiceItem[] voices = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "ÈÎÃüÖúÀí", "ÄãºÃÑ½²©Ê¿£¡", OperatorVoiceType.ChineseMandarin) };
+            OperatorVoiceItem[] voices = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "ä»»å‘½åŠ©ç†", "ä½ å¥½å‘€åšå£«ï¼", OperatorVoiceType.ChineseMandarin) };
 
             Operator testOperator1 = new(
                     "Baka632",
@@ -98,7 +98,7 @@ namespace ArknightsResources.Operators.Models.Test
         [Fact]
         public void OperatorEqualityTest()
         {
-            OperatorVoiceItem[] voicesA = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "ÈÎÃüÖúÀí", "ÄãºÃÑ½²©Ê¿£¡", OperatorVoiceType.ChineseMandarin) };
+            OperatorVoiceItem[] voicesA = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "ä»»å‘½åŠ©ç†", "ä½ å¥½å‘€åšå£«ï¼", OperatorVoiceType.ChineseMandarin) };
 
             Operator opA = new("Baka632",
                                         6,
@@ -110,7 +110,7 @@ namespace ArknightsResources.Operators.Models.Test
                                         new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVoiceType.ChineseMandarin, voicesA) },
                                         new OperatorProfile[] { new OperatorProfile("???", OperatorProfileType.Unknown) });
 
-            OperatorVoiceItem[] voicesB = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "ÈÎÃüÖúÀí", "ÄãºÃÑ½²©Ê¿£¡",OperatorVoiceType.ChineseMandarin) };
+            OperatorVoiceItem[] voicesB = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "ä»»å‘½åŠ©ç†", "ä½ å¥½å‘€åšå£«ï¼",OperatorVoiceType.ChineseMandarin) };
 
             Operator opB = new("Baka632",
                                         6,

--- a/test/OperatorModelsTest.cs
+++ b/test/OperatorModelsTest.cs
@@ -11,6 +11,8 @@ namespace ArknightsResources.Operators.Models.Test
         [Fact]
         public void OperatorSerializeAndDeserializeTest()
         {
+            OperatorVoiceItem[] voices = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！") };
+
             Operator testOperator = new("Baka632",
                                         6,
                                         "baka",
@@ -18,7 +20,7 @@ namespace ArknightsResources.Operators.Models.Test
                                         new OperatorBirthday(5, 14),
                                         new OperatorClass(OperatorMainClass.Supporter, OperatorBranchClass.Summoner),
                                         new OperatorIllustrationInfo[] { new OperatorIllustrationInfo("Traveler", "Travel for lights", "baka_travel", OperatorType.Skin, "Baka632") },
-                                        new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVocalType.ChineseMandarin) },
+                                        new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVoiceType.ChineseMandarin, voices) },
                                         new OperatorProfile[] { new OperatorProfile("???", OperatorProfileType.Unknown) });
             
             MemoryStream stream = new();
@@ -40,6 +42,8 @@ namespace ArknightsResources.Operators.Models.Test
         [Fact]
         public void OperatorsListSerializeAndDeserializeTest()
         {
+            OperatorVoiceItem[] voices = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！") };
+
             Operator testOperator1 = new(
                     "Baka632",
                     6,
@@ -48,7 +52,7 @@ namespace ArknightsResources.Operators.Models.Test
                     new OperatorBirthday(5, 14),
                     new OperatorClass(OperatorMainClass.Supporter, OperatorBranchClass.Summoner),
                     new OperatorIllustrationInfo[] { new OperatorIllustrationInfo("Traveler", "Travel for lights", "baka_travel", OperatorType.Skin, "Baka632") },
-                    new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVocalType.ChineseMandarin) },
+                    new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVoiceType.ChineseMandarin, voices) },
                     new OperatorProfile[] { new OperatorProfile("???", OperatorProfileType.Unknown) }
                 );
 
@@ -60,7 +64,7 @@ namespace ArknightsResources.Operators.Models.Test
                 new OperatorBirthday(5, 14),
                 new OperatorClass(OperatorMainClass.Specialist, OperatorBranchClass.Trapmaster),
                 new OperatorIllustrationInfo[] { new OperatorIllustrationInfo("Far", "Faraway", "ab_far", OperatorType.Skin, "Baka632") },
-                new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVocalType.ChineseMandarin) },
+                new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVoiceType.ChineseMandarin, voices) },
                 new OperatorProfile[] { new OperatorProfile("???", OperatorProfileType.Unknown) }
             );
 
@@ -89,6 +93,36 @@ namespace ArknightsResources.Operators.Models.Test
             {
                 Assert.Equal(item, opList[item.Codename]);
             }
+        }
+
+        [Fact]
+        public void OperatorEqualityTest()
+        {
+            OperatorVoiceItem[] voicesA = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！") };
+
+            Operator opA = new("Baka632",
+                                        6,
+                                        "baka",
+                                        OperatorGender.Male,
+                                        new OperatorBirthday(5, 14),
+                                        new OperatorClass(OperatorMainClass.Supporter, OperatorBranchClass.Summoner),
+                                        new OperatorIllustrationInfo[] { new OperatorIllustrationInfo("Traveler", "Travel for lights", "baka_travel", OperatorType.Skin, "Baka632") },
+                                        new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVoiceType.ChineseMandarin, voicesA) },
+                                        new OperatorProfile[] { new OperatorProfile("???", OperatorProfileType.Unknown) });
+
+            OperatorVoiceItem[] voicesB = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！") };
+
+            Operator opB = new("Baka632",
+                                        6,
+                                        "baka",
+                                        OperatorGender.Male,
+                                        new OperatorBirthday(5, 14),
+                                        new OperatorClass(OperatorMainClass.Supporter, OperatorBranchClass.Summoner),
+                                        new OperatorIllustrationInfo[] { new OperatorIllustrationInfo("Traveler", "Travel for lights", "baka_travel", OperatorType.Skin, "Baka632") },
+                                        new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVoiceType.ChineseMandarin, voicesB) },
+                                        new OperatorProfile[] { new OperatorProfile("???", OperatorProfileType.Unknown) });
+
+            Assert.Equal(opA, opB);
         }
     }
 }


### PR DESCRIPTION
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮 -->

## 描述

1. ✨添加OperatorVoiceItem结构

2. 💥破坏性更改：
    - OperatorVocalType枚举更名为OperatorVoiceType
    - OperatorVoiceInfo的Voice属性更名为CV，添加Voices属性，为其构造器添加参数
    - Operator对象变为不可变类型

3. ✅添加验证值相等性的测试
4. 🔖0.1.6.0
<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？
- Operator对象为可变类型
- OperatorVocalType的名称与其他相关结构不统一

<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->

## 新的行为是什么？
- 添加OperatorVoiceItem结构
- Operator对象为不可变类型
- OperatorVocalType的名称改为OperatorVoiceType
<!-- 描述你解决了什么问题，现在的行为是什么 -->

## 备注
破坏性更改指南：

- 将代码中的OperatorVocalType改为OperatorVoiceType
- 更改Operator对象内数据的程序现在应该提前准备好数据，并且通过构造器创建Operator的实例
- 使用OperatorVoiceInfo的Voice属性的程序应该改为使用CV属性
- 实例化OperatorVoiceInfo时应该向构造器多传递一个OperatorVoiceItem数组

<!-- 请添加任何你认为有帮助的信息 -->
<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->