### PR TITLE
更改OperatorVoiceItem的名称为OperatorVoiceLine

### DIFF
--- a/src/ArknightsResources.Operators.Models.csproj
+++ b/src/ArknightsResources.Operators.Models.csproj
@@ -17,9 +17,9 @@
     <Description>Provides models about Arknights Operators</Description>
     <IsTrimmable>true</IsTrimmable>
     <AnalysisLevel>latest</AnalysisLevel>
-    <Version>0.2.0.0-alpha</Version>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <FileVersion>0.2.0.0</FileVersion>
+    <Version>0.2.1.0-alpha</Version>
+    <AssemblyVersion>0.2.1.0</AssemblyVersion>
+    <FileVersion>0.2.1.0</FileVersion>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <DebugType>portable</DebugType>

--- a/src/OpVoice/OperatorVoiceInfo.cs
+++ b/src/OpVoice/OperatorVoiceInfo.cs
@@ -19,7 +19,7 @@ namespace ArknightsResources.Operators.Models
         /// <param name="type">配音的语言种类</param>
         /// <param name="voices">语音条目</param>
         [JsonConstructor]
-        public OperatorVoiceInfo(string cv, OperatorVoiceType type, OperatorVoiceItem[] voices)
+        public OperatorVoiceInfo(string cv, OperatorVoiceType type, OperatorVoiceLine[] voices)
         {
             CV = cv;
             Type = type;
@@ -39,7 +39,7 @@ namespace ArknightsResources.Operators.Models
         /// <summary>
         /// 干员的语音条目
         /// </summary>
-        public OperatorVoiceItem[] Voices { get; }
+        public OperatorVoiceLine[] Voices { get; }
 
         private string GetDebuggerDisplay()
         {
@@ -66,7 +66,7 @@ namespace ArknightsResources.Operators.Models
             int hashCode = 291305966;
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CV);
             hashCode = hashCode * -1521134295 + Type.GetHashCode();
-            hashCode = hashCode * -1521134295 + EqualityComparer<OperatorVoiceItem[]>.Default.GetHashCode(Voices);
+            hashCode = hashCode * -1521134295 + EqualityComparer<OperatorVoiceLine[]>.Default.GetHashCode(Voices);
             return hashCode;
         }
 

--- a/src/OpVoice/OperatorVoiceLine.cs
+++ b/src/OpVoice/OperatorVoiceLine.cs
@@ -9,10 +9,10 @@ namespace ArknightsResources.Operators.Models
     /// 表示一条干员语音的结构
     /// </summary>
     [DebuggerDisplay("{" + nameof(GetDebuggerDisplay) + "(),nq}")]
-    public readonly struct OperatorVoiceItem : IEquatable<OperatorVoiceItem>
+    public readonly struct OperatorVoiceLine : IEquatable<OperatorVoiceLine>
     {
         /// <summary>
-        /// 初始化<see cref="OperatorVoiceItem"/>结构的新实例
+        /// 初始化<see cref="OperatorVoiceLine"/>结构的新实例
         /// </summary>
         /// <param name="charactorCodename">该条语音所属干员的内部代号</param>
         /// <param name="voiceId">该条语音的包内ID(如"CN_007")</param>
@@ -20,7 +20,7 @@ namespace ArknightsResources.Operators.Models
         /// <param name="voiceText">该条语音的文本</param>
         /// <param name="voiceType">该条语音的语言种类</param>
         [JsonConstructor]
-        public OperatorVoiceItem(string charactorCodename, string voiceId, string voiceTitle, string voiceText, OperatorVoiceType voiceType)
+        public OperatorVoiceLine(string charactorCodename, string voiceId, string voiceTitle, string voiceText, OperatorVoiceType voiceType)
         {
             CharactorCodename = charactorCodename;
             VoiceId = voiceId;
@@ -62,11 +62,11 @@ namespace ArknightsResources.Operators.Models
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            return obj is OperatorVoiceItem item && Equals(item);
+            return obj is OperatorVoiceLine item && Equals(item);
         }
 
         /// <inheritdoc/>
-        public bool Equals(OperatorVoiceItem other)
+        public bool Equals(OperatorVoiceLine other)
         {
             return CharactorCodename == other.CharactorCodename &&
                    VoiceId == other.VoiceId &&
@@ -88,13 +88,13 @@ namespace ArknightsResources.Operators.Models
         }
 
         /// <inheritdoc/>
-        public static bool operator ==(OperatorVoiceItem left, OperatorVoiceItem right)
+        public static bool operator ==(OperatorVoiceLine left, OperatorVoiceLine right)
         {
             return left.Equals(right);
         }
 
         /// <inheritdoc/>
-        public static bool operator !=(OperatorVoiceItem left, OperatorVoiceItem right)
+        public static bool operator !=(OperatorVoiceLine left, OperatorVoiceLine right)
         {
             return !(left == right);
         }

--- a/test/OperatorModelsTest.cs
+++ b/test/OperatorModelsTest.cs
@@ -11,7 +11,7 @@ namespace ArknightsResources.Operators.Models.Test
         [Fact]
         public void OperatorSerializeAndDeserializeTest()
         {
-            OperatorVoiceItem[] voices = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！", OperatorVoiceType.ChineseMandarin) };
+            OperatorVoiceLine[] voices = new OperatorVoiceLine[] { new OperatorVoiceLine("baka", "CN_001", "任命助理", "你好呀博士！", OperatorVoiceType.ChineseMandarin) };
 
             Operator testOperator = new("Baka632",
                                         6,
@@ -42,7 +42,7 @@ namespace ArknightsResources.Operators.Models.Test
         [Fact]
         public void OperatorEqualityTest()
         {
-            OperatorVoiceItem[] voicesA = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！", OperatorVoiceType.ChineseMandarin) };
+            OperatorVoiceLine[] voicesA = new OperatorVoiceLine[] { new OperatorVoiceLine("baka", "CN_001", "任命助理", "你好呀博士！", OperatorVoiceType.ChineseMandarin) };
 
             Operator opA = new("Baka632",
                                         6,
@@ -54,7 +54,7 @@ namespace ArknightsResources.Operators.Models.Test
                                         new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVoiceType.ChineseMandarin, voicesA) },
                                         new OperatorProfile[] { new OperatorProfile("???", OperatorProfileType.Unknown) });
 
-            OperatorVoiceItem[] voicesB = new OperatorVoiceItem[] { new OperatorVoiceItem("baka", "CN_001", "任命助理", "你好呀博士！",OperatorVoiceType.ChineseMandarin) };
+            OperatorVoiceLine[] voicesB = new OperatorVoiceLine[] { new OperatorVoiceLine("baka", "CN_001", "任命助理", "你好呀博士！",OperatorVoiceType.ChineseMandarin) };
 
             Operator opB = new("Baka632",
                                         6,


### PR DESCRIPTION
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮 -->

## 描述
💥更改OperatorVoiceItem的名称为OperatorVoiceLine
🔖0.2.1.0
<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
- 其他，请描述内容：更名

## 当前行为是什么？
OperatorVoiceItem这一名称不能清晰地表达其类型用途
<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->

## 新的行为是什么？
OperatorVoiceItem改为OperatorVoiceLine，这一名称能够较为清晰地表达其用途
<!-- 描述你解决了什么问题，现在的行为是什么 -->

## 备注
代码中使用OperatorVoiceItem的代码只需要将其改为OperatorVoiceLine即可
<!-- 请添加任何你认为有帮助的信息 -->
<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->