### PR TITLE
为OperatorVoiceType添加"None"成员

### DIFF
--- a/src/ArknightsResources.Operators.Models.csproj
+++ b/src/ArknightsResources.Operators.Models.csproj
@@ -9,7 +9,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <PackageProjectUrl>https://github.com/ArknightsResources/Home</PackageProjectUrl>
-    <Copyright>Copyright (c) 2022 Baka632</Copyright>
+    <Copyright>Copyright (c) 2023 Baka632</Copyright>
     <PackageTags>Arknights;明日方舟</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -17,9 +17,7 @@
     <Description>Provides models about Arknights Operators</Description>
     <IsTrimmable>true</IsTrimmable>
     <AnalysisLevel>latest</AnalysisLevel>
-    <Version>0.2.1.0-alpha</Version>
-    <AssemblyVersion>0.2.1.0</AssemblyVersion>
-    <FileVersion>0.2.1.0</FileVersion>
+    <Version>0.2.2.0-alpha</Version>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <DebugType>portable</DebugType>

--- a/src/OpVoice/OperatorVoiceType.cs
+++ b/src/OpVoice/OperatorVoiceType.cs
@@ -6,6 +6,10 @@
     public enum OperatorVoiceType
     {
         /// <summary>
+        /// 无语言倾向
+        /// </summary>
+        None,
+        /// <summary>
         /// 中文普通话
         /// </summary>
         ChineseMandarin,


### PR DESCRIPTION
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮 -->

## 描述
✨为OperatorVoiceType添加"None"成员以适应更新
🔖0.2.2.0
<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？
OperatorVoiceType仅有 汉语、日语、英语、韩语、和意大利语的成员
<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->

## 新的行为是什么？
为OperatorVoiceType添加"None"成员以指示语音无语音倾向(如“泰拉大陆调查团”)
<!-- 描述你解决了什么问题，现在的行为是什么 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->