### PR TITLE
OperatorIllustrationInfo添加了立绘原案属性，添加了引用类型可空性注释

### DIFF
--- a/src/ArknightsResources.Operators.Models.csproj
+++ b/src/ArknightsResources.Operators.Models.csproj
@@ -17,10 +17,12 @@
     <Description>Provides models about Arknights Operators</Description>
     <IsTrimmable>true</IsTrimmable>
     <AnalysisLevel>latest</AnalysisLevel>
-    <Version>0.2.2.0-alpha</Version>
+    <Version>0.3.0.0-alpha</Version>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <DebugType>portable</DebugType>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/src/OpVoice/OperatorVoiceInfo.cs
+++ b/src/OpVoice/OperatorVoiceInfo.cs
@@ -21,9 +21,9 @@ namespace ArknightsResources.Operators.Models
         [JsonConstructor]
         public OperatorVoiceInfo(string cv, OperatorVoiceType type, OperatorVoiceLine[] voices)
         {
-            CV = cv;
+            CV = cv ?? throw new ArgumentNullException(nameof(cv));
             Type = type;
-            Voices = voices;
+            Voices = voices ?? throw new ArgumentNullException(nameof(voices));
         }
 
         /// <summary>

--- a/src/OpVoice/OperatorVoiceLine.cs
+++ b/src/OpVoice/OperatorVoiceLine.cs
@@ -22,10 +22,10 @@ namespace ArknightsResources.Operators.Models
         [JsonConstructor]
         public OperatorVoiceLine(string charactorCodename, string voiceId, string voiceTitle, string voiceText, OperatorVoiceType voiceType)
         {
-            CharactorCodename = charactorCodename;
-            VoiceId = voiceId;
-            VoiceTitle = voiceTitle;
-            VoiceText = voiceText;
+            CharactorCodename = charactorCodename ?? throw new ArgumentNullException(nameof(charactorCodename));
+            VoiceId = voiceId ?? throw new ArgumentNullException(nameof(voiceId));
+            VoiceTitle = voiceTitle ?? throw new ArgumentNullException(nameof(voiceTitle));
+            VoiceText = voiceText ?? throw new ArgumentNullException(nameof(voiceText));
             VoiceType = voiceType;
         }
 

--- a/src/Operator.cs
+++ b/src/Operator.cs
@@ -25,17 +25,17 @@ namespace ArknightsResources.Operators.Models
         /// <param name="voices">干员配音信息</param>
         /// <param name="profiles">干员档案信息</param>
         [JsonConstructor]
-        public Operator(string name, int star, string codename, OperatorGender gender, OperatorBirthday? birthday, OperatorClass @class, OperatorIllustrationInfo[] illustrations, OperatorVoiceInfo[] voices, OperatorProfile[] profiles)
+        public Operator(string name, string codename, int star, OperatorGender gender, OperatorBirthday? birthday, OperatorClass @class, OperatorIllustrationInfo[] illustrations, OperatorVoiceInfo[] voices, OperatorProfile[] profiles)
         {
-            Name = name;
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Codename = codename ?? throw new ArgumentNullException(nameof(codename));
             Star = star;
-            Codename = codename;
             Gender = gender;
             Birthday = birthday;
             Class = @class;
-            Illustrations = illustrations;
-            Voices = voices;
-            Profiles = profiles;
+            Illustrations = illustrations ?? throw new ArgumentNullException(nameof(illustrations));
+            Voices = voices ?? throw new ArgumentNullException(nameof(voices));
+            Profiles = profiles ?? throw new ArgumentNullException(nameof(profiles));
         }
 
         /// <summary>

--- a/src/OperatorBirthday.cs
+++ b/src/OperatorBirthday.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
 
 namespace ArknightsResources.Operators.Models
@@ -6,6 +7,7 @@ namespace ArknightsResources.Operators.Models
     /// <summary>
     /// 表示干员生日的结构
     /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
     public readonly struct OperatorBirthday : IEquatable<OperatorBirthday>
     {
         /// <summary>

--- a/src/OperatorIllustrationInfo.cs
+++ b/src/OperatorIllustrationInfo.cs
@@ -17,16 +17,23 @@ namespace ArknightsResources.Operators.Models
         /// <param name="imageCodename">立绘图片代号</param>
         /// <param name="type">立绘类型</param>
         /// <param name="illustrator">立绘画师</param>
+        /// <param name="designer">立绘原案</param>
         [JsonConstructor]
-        public OperatorIllustrationInfo(string illustrationName, string description, string imageCodename,
-                                        OperatorType type, string illustrator)
+        public OperatorIllustrationInfo(OperatorType type, string illustrationName, string description, string imageCodename,
+                                        string illustrator, string? designer)
         {
-            IllustrationName = illustrationName;
-            Description = description;
-            ImageCodename = imageCodename;
             Type = type;
-            Illustrator = illustrator;
+            IllustrationName = illustrationName ?? throw new ArgumentNullException(nameof(illustrationName));
+            Description = description ?? throw new ArgumentNullException(nameof(description));
+            ImageCodename = imageCodename ?? throw new ArgumentNullException(nameof(imageCodename));
+            Illustrator = illustrator ?? throw new ArgumentNullException(nameof(illustrator));
+            Designer = designer;
         }
+
+        /// <summary>
+        /// 此立绘的种类
+        /// </summary>
+        public OperatorType Type { get; }
 
         /// <summary>
         /// 立绘名称
@@ -44,14 +51,14 @@ namespace ArknightsResources.Operators.Models
         public string ImageCodename { get; }
 
         /// <summary>
-        /// 此立绘的种类
-        /// </summary>
-        public OperatorType Type { get; }
-
-        /// <summary>
         /// 立绘画师
         /// </summary>
         public string Illustrator { get; }
+
+        /// <summary>
+        /// 立绘原案
+        /// </summary>
+        public string? Designer { get; }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
@@ -66,7 +73,8 @@ namespace ArknightsResources.Operators.Models
                    Description == other.Description &&
                    ImageCodename == other.ImageCodename &&
                    Type == other.Type &&
-                   Illustrator == other.Illustrator;
+                   Illustrator == other.Illustrator &&
+                   Designer == other.Designer;
         }
 
         /// <inheritdoc/>
@@ -78,13 +86,14 @@ namespace ArknightsResources.Operators.Models
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ImageCodename);
             hashCode = hashCode * -1521134295 + Type.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Illustrator);
+            hashCode = hashCode * -1521134295 + (Designer != null ? EqualityComparer<string>.Default.GetHashCode(Designer) : 0);
             return hashCode;
         }
 
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"Name:{IllustrationName};IllustType:{Type};IllustCodename:{ImageCodename};Illustrator:{Illustrator}";
+            return $"Name:{IllustrationName};IllustType:{Type};IllustCodename:{ImageCodename};Illustrator:{Illustrator};Designer:{Designer}";
         }
 
         /// <inheritdoc/>

--- a/src/OperatorProfile.cs
+++ b/src/OperatorProfile.cs
@@ -17,7 +17,7 @@ namespace ArknightsResources.Operators.Models
         [JsonConstructor]
         public OperatorProfile(string profile, OperatorProfileType type)
         {
-            Profile = profile;
+            Profile = profile ?? throw new ArgumentNullException(nameof(profile));
             Type = type;
         }
 

--- a/test/OperatorModelsTest.cs
+++ b/test/OperatorModelsTest.cs
@@ -14,12 +14,12 @@ namespace ArknightsResources.Operators.Models.Test
             OperatorVoiceLine[] voices = new OperatorVoiceLine[] { new OperatorVoiceLine("baka", "CN_001", "任命助理", "你好呀博士！", OperatorVoiceType.ChineseMandarin) };
 
             Operator testOperator = new("Baka632",
-                                        6,
                                         "baka",
+                                        6,
                                         OperatorGender.Male,
                                         new OperatorBirthday(5, 14),
                                         new OperatorClass(OperatorMainClass.Supporter, OperatorBranchClass.Summoner),
-                                        new OperatorIllustrationInfo[] { new OperatorIllustrationInfo("Traveler", "Travel for lights", "baka_travel", OperatorType.Skin, "Baka632") },
+                                        new OperatorIllustrationInfo[] { new OperatorIllustrationInfo(OperatorType.Skin, "Traveler", "Travel for lights", "baka_travel", "Baka632",null) },
                                         new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVoiceType.ChineseMandarin, voices) },
                                         new OperatorProfile[] { new OperatorProfile("???", OperatorProfileType.Unknown) });
             
@@ -45,24 +45,24 @@ namespace ArknightsResources.Operators.Models.Test
             OperatorVoiceLine[] voicesA = new OperatorVoiceLine[] { new OperatorVoiceLine("baka", "CN_001", "任命助理", "你好呀博士！", OperatorVoiceType.ChineseMandarin) };
 
             Operator opA = new("Baka632",
-                                        6,
                                         "baka",
+                                        6,
                                         OperatorGender.Male,
                                         new OperatorBirthday(5, 14),
                                         new OperatorClass(OperatorMainClass.Supporter, OperatorBranchClass.Summoner),
-                                        new OperatorIllustrationInfo[] { new OperatorIllustrationInfo("Traveler", "Travel for lights", "baka_travel", OperatorType.Skin, "Baka632") },
+                                        new OperatorIllustrationInfo[] { new OperatorIllustrationInfo(OperatorType.Skin, "Traveler", "Travel for lights", "baka_travel", "Baka632", null) },
                                         new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVoiceType.ChineseMandarin, voicesA) },
                                         new OperatorProfile[] { new OperatorProfile("???", OperatorProfileType.Unknown) });
 
             OperatorVoiceLine[] voicesB = new OperatorVoiceLine[] { new OperatorVoiceLine("baka", "CN_001", "任命助理", "你好呀博士！",OperatorVoiceType.ChineseMandarin) };
 
             Operator opB = new("Baka632",
-                                        6,
                                         "baka",
+                                        6,
                                         OperatorGender.Male,
                                         new OperatorBirthday(5, 14),
                                         new OperatorClass(OperatorMainClass.Supporter, OperatorBranchClass.Summoner),
-                                        new OperatorIllustrationInfo[] { new OperatorIllustrationInfo("Traveler", "Travel for lights", "baka_travel", OperatorType.Skin, "Baka632") },
+                                        new OperatorIllustrationInfo[] { new OperatorIllustrationInfo(OperatorType.Skin, "Traveler", "Travel for lights", "baka_travel", "Baka632", null) },
                                         new OperatorVoiceInfo[] { new OperatorVoiceInfo("Baka632", OperatorVoiceType.ChineseMandarin, voicesB) },
                                         new OperatorProfile[] { new OperatorProfile("???", OperatorProfileType.Unknown) });
 


### PR DESCRIPTION
<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮 -->

## 描述
✨添加了引用类型可空性注释，OperatorIllustrationInfo添加了Designer(立绘原案)属性
💥Operator类参数顺序改变
🔧将C#语言版本设置为8.0，启用可空性注释
✅更新单元测试代码
🔖0.3.0.0
<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
- 代码样式更新
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？
OperatorIllustrationInfo缺少立绘原案属性，添加了引用类型可空性注释
<!-- 请描述应用在你修复之前的行为，或者添加 Issue 链接 -->

## 新的行为是什么？
为OperatorIllustrationInfo添加立绘原案属性
为整个项目添加了引用类型可空性注释
<!-- 描述你解决了什么问题，现在的行为是什么 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->